### PR TITLE
GH-72: refresh kanban returns home

### DIFF
--- a/src/app/auth.ts
+++ b/src/app/auth.ts
@@ -1,21 +1,19 @@
-import SteamProvider, {PROVIDER_ID} from 'next-auth-steam'
+import SteamProvider, {STEAM_PROVIDER_ID} from 'next-auth-steam'
 
 import type {AuthOptions, Session} from 'next-auth'
 import type {NextRequest} from 'next/server'
 
-export function getAuthOptions(req?: NextRequest): AuthOptions {
+export function getAuthOptions(req: NextRequest): AuthOptions {
     return {
-        providers: req
-            ? [
-                SteamProvider(req, {
-                    clientSecret: process.env.STEAM_SECRET!,
-                    callbackUrl: `${process.env.NEXTAUTH_URL}/api/auth/callback`
-                })
-            ]
-            : [],
+        providers: [
+            SteamProvider(req, {
+                clientSecret: process.env.STEAM_SECRET!,
+                callbackUrl: `${process.env.NEXTAUTH_URL}/api/auth/callback`,
+            })
+        ],
         callbacks: {
             jwt({ token, account, profile }) {
-                if (account?.provider === PROVIDER_ID) {
+                if (account?.provider === STEAM_PROVIDER_ID) {
                     token.steam = profile
                 }
                 return token

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -32,8 +32,11 @@ export default function GameListPage() {
     const session = useSession()
     
     useEffect(() => {
-        getGames(session.data).then(setGames)
-    }, [router, session]);
+        if (session.status == 'authenticated') {
+            getGames(session.data)
+                .then(setGames);
+        }
+    }, [router, session, setGames]);
 
     if (games == null) {
         return (

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, {useEffect, useState} from "react";
 import {CircularProgress} from "@mui/material";
+import BrokenImageIcon from '@mui/icons-material/BrokenImage';
 import {Game} from "@/entities/Game";
 import getGames from "@/services/getGames";
 import Image from "next/image";
@@ -9,15 +10,20 @@ import {useRouter} from "next/navigation";
 import {useSession} from "next-auth/react";
 
 function GameCard({game}: { game: Game }): React.ReactElement {
+
+    const [isError, setError] = useState(false)
+
     return (
         <Link href={"/kanban/" + game.appId}>
             <div className={"flex flex-col w-60"}>
                 <div className={"relative w-60 h-96 bg-amber-800 rounded-sm"}>
-                    <Image fill={true}
-                           title={game.title}
-                           src={game.cover_img_url}
-                           className={"rounded-sm border-none"}
-                           alt={""}/>
+                    {!isError ? <Image fill={true}
+                                       title={game.title}
+                                       src={game.cover_img_url}
+                                       onError={() => setError(true)}
+                                       className={"rounded-sm border-none"}
+                                       alt={"No cover art found"}/> : <div className={"h-96 flex flex-col items-center m-auto"}><BrokenImageIcon className={"flex flex-grow text-5xl"}/></div>}
+
                 </div>
                 <div className={"overflow-auto text-center"}>{game.title}</div>
             </div>

--- a/src/app/kanban/[appId]/page.tsx
+++ b/src/app/kanban/[appId]/page.tsx
@@ -14,8 +14,8 @@ export default function KanbanBoardPage(params: {params: Promise<{ appId: string
     const session = useSession()
     useEffect(() => {
         params.params.then((resp) => {
-            setAppId(resp.appId)
             if (session.status === "authenticated") {
+                setAppId(resp.appId)
                 getAchievementData({appId: resp.appId}, session.data).then((resp) => {
                     setAchievements(resp);
                 }).catch(() => router.push("/"))

--- a/src/components/steam-buttons/buttons.tsx
+++ b/src/components/steam-buttons/buttons.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { signIn, signOut } from 'next-auth/react'
+import {signIn, signOut} from 'next-auth/react'
 
 export function SignIn() {
-    return <button onClick={() => signIn()}>Sign In</button>
+    return <button onClick={() => signIn("steam")}>Sign In</button>
 }
 
 export function SignOut() {
-    return <button onClick={() => signOut()}>Sign Out</button>
+    return <button onClick={() => signOut({callbackUrl: '/'})}>Sign Out</button>
 }

--- a/src/components/welcome-landing/welcome-landing.tsx
+++ b/src/components/welcome-landing/welcome-landing.tsx
@@ -1,36 +1,28 @@
 'use client'
 
-import {Button,} from "@mui/material";
+import {Button, CircularProgress,} from "@mui/material";
 import Link from "next/link";
-import {useSession} from "next-auth/react";
+import {SessionContextValue, signIn, useSession} from "next-auth/react";
+import React, {ReactElement} from "react";
 
 export default function Home() {
-    const session = useSession()
+    const {status, data} = useSession()
 
-    const sessionLayout = <div>
-        <ul>
-            <li>Session status: {session.status}</li>
-            <li>
-                Session data:
-                <pre>{JSON.stringify(session.data, null, 2)}</pre>
-            </li>
+    const contentStates: Record<SessionContextValue['status'], ReactElement> = {
+        'authenticated': <Link href={"/games"}><Button variant={"contained"} color={"primary"}>View game
+            list</Button></Link>,
+        'unauthenticated': <Button variant={"contained"} onClick={() => signIn("steam")}>Sign in</Button>,
+        'loading': <CircularProgress size="2rem" className="m-auto"/>
+    }
 
-            <li>
-                Session test: {session?.data?.user?.steam?.steamid}
-            </li>
-        </ul>
-    </div>
-
-    const linkToGamesPage = <Link href={"/games"}><Button variant={"contained"} color={"primary"}>View game
-        list</Button></Link>
-
+    const username = data?.user?.name;
 
     return (
         <div className="w-full h-full flex flex-col items-center justify-around">
-            <div className={"flex flex-col gap-4"}>
+            <div className={"flex flex-col gap-4 items-center"}>
                 <h1 className={"text-4xl font-bold"}>Welcome to Achievemint!</h1>
-                {sessionLayout}
-                {linkToGamesPage}
+                {username && <h2 className={"text-2xl"}>Hello, {username}!</h2>}
+                {contentStates[status]}
             </div>
         </div>
     )

--- a/src/services/getAchievementData.ts
+++ b/src/services/getAchievementData.ts
@@ -1,7 +1,7 @@
 import {Achievement} from "@/entities/Achievement";
 import {Session} from "next-auth";
 
-export default async function getAchievementData(args: {appId: string}, session: Session | null): Promise<Array<Achievement>> {
+export default async function getAchievementData(args: {appId: string}, session: Session): Promise<Array<Achievement>> {
     const steamId = session?.user?.steam?.steamid
     const resp = await (await fetch(`/api/achievementData?appid=${args.appId}&steamid=${steamId}&l=en_us`)).json()
 

--- a/src/services/getGames.ts
+++ b/src/services/getGames.ts
@@ -1,7 +1,7 @@
 import {Game} from "@/entities/Game";
 import {Session} from "next-auth";
 
-export default async function getGames(session: Session | null): Promise<Array<Game>> {
+export default async function getGames(session: Session): Promise<Array<Game>> {
     const steamId = session?.user?.steam?.steamid
     const response = await fetch(`/api/games?&steamid=${steamId}`);
     return (await response.json()).games;


### PR DESCRIPTION
- Fixed redirect on refresh of Kanban board
- Improved "not found" state of cover art
- Cleanup for welcome/landing page
- make sure you can't `view game list` which not signed in

![image](https://github.com/user-attachments/assets/bcbb1d32-9b95-4156-8019-46efb8c91b41)
![image](https://github.com/user-attachments/assets/59e87d0d-cf2a-465f-ba86-11883b2c4b87)

closes #72 